### PR TITLE
chore: add jsx-nbsp autofix workflow and eslint rule

### DIFF
--- a/.github/workflows/jsx-nbsp.yml
+++ b/.github/workflows/jsx-nbsp.yml
@@ -1,0 +1,23 @@
+# Installed into each React repo as .github/workflows/jsx-nbsp.yml by
+# scripts/rollout.sh. On every PR it autofixes JSX dash widows and commits the
+# fix back to the PR branch. Pinned to @v1 of digitalby-me/jsx-nbsp-lint.
+name: jsx-nbsp
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: jsx-nbsp-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  jsx-nbsp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: digitalby-me/jsx-nbsp-lint@v1

--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
+
+export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,16 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import nextVitals from "eslint-config-next/core-web-vitals";
-import nextTs from "eslint-config-next/typescript";
+import base from "./eslint.config.base.mjs";
+import jsxNbsp from "eslint-plugin-jsx-nbsp";
 
-const eslintConfig = defineConfig([
-  ...nextVitals,
-  ...nextTs,
-  // Override default ignores of eslint-config-next.
-  globalIgnores([
-    // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-  ]),
-]);
+const baseConfig = Array.isArray(base) ? base : [base];
 
-export default eslintConfig;
+export default [
+  ...baseConfig,
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: { "jsx-nbsp": jsxNbsp },
+    rules: {
+      "jsx-nbsp/no-breaking-space-before-dash": "error",
+      "jsx-nbsp/no-text-to-text-jsx-space": "warn",
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9",
         "eslint-config-next": "^16.2.6",
+        "eslint-plugin-jsx-nbsp": "github:digitalby-me/jsx-nbsp-lint#v1",
         "jsdom": "^29.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -5601,6 +5602,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-nbsp": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/digitalby-me/jsx-nbsp-lint.git#864af2268324ade2c60ab536a5b3b9c46dfeca42",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsx-nbsp": "bin/jsx-nbsp.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
       }
     },
     "node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9",
     "eslint-config-next": "^16.2.6",
+    "eslint-plugin-jsx-nbsp": "github:digitalby-me/jsx-nbsp-lint#v1",
     "jsdom": "^29.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",


### PR DESCRIPTION
Adds the jsx-nbsp autofix workflow (fixes a breaking space before an em/en dash on every PR and commits it back) and wires the rule into the local ESLint config for in-editor feedback. Fleet-wide rollout from https://github.com/digitalby-me/jsx-nbsp-lint.