### PR TITLE
fix: https tarball devDep so npm install works keyless

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
   ...baseConfig,
   {
     files: ["**/*.{jsx,tsx}"],
+    languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
     plugins: { "jsx-nbsp": jsxNbsp },
     rules: {
       "jsx-nbsp/no-breaking-space-before-dash": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9",
         "eslint-config-next": "^16.2.6",
-        "eslint-plugin-jsx-nbsp": "github:digitalby-me/jsx-nbsp-lint#v1",
+        "eslint-plugin-jsx-nbsp": "https://github.com/digitalby-me/jsx-nbsp-lint/archive/refs/tags/v1.0.0.tar.gz",
         "jsdom": "^29.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -5606,7 +5606,8 @@
     },
     "node_modules/eslint-plugin-jsx-nbsp": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/digitalby-me/jsx-nbsp-lint.git#864af2268324ade2c60ab536a5b3b9c46dfeca42",
+      "resolved": "https://github.com/digitalby-me/jsx-nbsp-lint/archive/refs/tags/v1.0.0.tar.gz",
+      "integrity": "sha512-I70L9MrHS95IJ2BUnUNQi+bMNEP/SQ5rS1g+2C0Ev/lG0xm9tJ8EisCrIIi39bP7cZhgaWapmq7dRTJPoVaYeg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9",
     "eslint-config-next": "^16.2.6",
-    "eslint-plugin-jsx-nbsp": "github:digitalby-me/jsx-nbsp-lint#v1",
+    "eslint-plugin-jsx-nbsp": "https://github.com/digitalby-me/jsx-nbsp-lint/archive/refs/tags/v1.0.0.tar.gz",
     "jsdom": "^29.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",


### PR DESCRIPTION
npm rewrote the github: devDep to a git+ssh lockfile URL that Vercel cannot fetch (no SSH key), breaking deploys. Pin to an immutable https release tarball instead. Also enables jsx parsing in the eslint wrapper. Found by Codex on the rollout PR.